### PR TITLE
Move order debug to profile

### DIFF
--- a/resources/views/carrinho/index.blade.php
+++ b/resources/views/carrinho/index.blade.php
@@ -225,12 +225,6 @@
         </div>
     @endif
 
-    {{-- DEBUG: Mostrar quantidade de pedidos --}}
-    @if(isset($pedidos))
-        <div class="alert alert-info"><b>Debug:</b> Total de pedidos encontrados: {{ count($pedidos) }}<br>
-        IDs: @foreach($pedidos as $p) {{ $p->id }} @endforeach
-        </div>
-    @endif
     {{-- Histórico de Pedidos --}}
     @if(isset($pedidos) && count($pedidos) > 0)
     <div class="row mt-5">

--- a/resources/views/profile/partials/orders-section.blade.php
+++ b/resources/views/profile/partials/orders-section.blade.php
@@ -76,6 +76,14 @@
     </div>
     
     <div class="p-6">
+        {{-- DEBUG: Mostrar quantidade de pedidos --}}
+        @if(isset($pedidos))
+            <div class="mb-4 p-4 text-sm text-blue-800 bg-blue-50 rounded-lg">
+                <b>Debug:</b> Total de pedidos encontrados: {{ $pedidos->count() }}<br>
+                IDs: @foreach($pedidos as $p) {{ $p->id }} @endforeach
+            </div>
+        @endif
+
         @if(isset($pedidos) && $pedidos->count() > 0)
             <div class="space-y-4">
                 @foreach($pedidos as $pedido)


### PR DESCRIPTION
## Summary
- remove the debug alert from the cart page
- show the order count debug info in the profile "Meus Pedidos" section

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fdc2395788331b61dab61355a64f5